### PR TITLE
fix: support mermaid v9 by falling back to mermaid.init()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 [![npm version](https://badge.fury.io/js/docsify-mermaid.svg)](https://www.npmjs.com/package/docsify-mermaid)
 
-mermaid-docsify is a docsify plugin which allows to render mermaid diagrams in docsify.
+mermaid-docsify is a docsify plugin which allows to render mermaid diagrams in docsify. Supports both mermaid v9 and v10+.
 
 ## How to use
 
-Add Mermaid and the plugin:
+Add Mermaid and the plugin. Choose the option matching your mermaid version:
+
+### Mermaid v10+ (ESM)
 
 ```html
   <script type="module">
@@ -15,7 +17,17 @@ Add Mermaid and the plugin:
   <script src="//unpkg.com/docsify-mermaid@2.0.1/dist/docsify-mermaid.js"></script>
 ```
 
-You can optionally customize [mermaid.run](https://mermaid.js.org/config/usage.html#using-mermaid-run) configuration with this props :
+### Mermaid v9 (regular script)
+
+```html
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.min.js"></script>
+  <script>
+    mermaid.initialize({ startOnLoad: false });
+  </script>
+  <script src="//unpkg.com/docsify-mermaid@2.0.1/dist/docsify-mermaid.js"></script>
+```
+
+You can optionally customize [mermaid.run](https://mermaid.js.org/config/usage.html#using-mermaid-run) (v10+) or [mermaid.init](https://mermaid.js.org/config/usage.html) (v9) configuration with this props:
 
 ```html
   <script>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -18,7 +18,15 @@ const plugin = (mermaidConf) => (hook) => {
         next(htmlElement.innerHTML);
     });
 
-    hook.doneEach(() => mermaid.run(mermaidConf));
+    hook.doneEach(() => {
+        if (typeof mermaid.run === 'function') {
+            // mermaid.run() is the v10+ API (requires ESM import)
+            mermaid.run(mermaidConf);
+        } else {
+            // mermaid.init() is the v9 API (works with regular <script> tags)
+            mermaid.init(undefined, mermaidConf.querySelector || '.mermaid');
+        }
+    });
 
 };
 


### PR DESCRIPTION
## Problem

`docsify-mermaid@2.0.1` calls `mermaid.run()` which only exists in 
mermaid v10+. However, mermaid v10 requires ESM imports (`type="module"`), 
which load asynchronously — meaning `window.mermaid` is undefined when the 
plugin tries to use it.

Mermaid v9 loads synchronously via a regular `<script>` tag but only 
exposes `mermaid.init()`, not `mermaid.run()`.

This makes the plugin broken for both versions.

## Fix

Fall back to `mermaid.init()` when `mermaid.run()` is not available, 
supporting both v9 and v10+.

## Changes

- `src/plugin.js`: check `typeof mermaid.run === 'function'` before 
  calling it; fall back to `mermaid.init()` for v9
- 'README.md': updated readme to support both implementations